### PR TITLE
Maintenance fixes for Windows build and pprof binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you want to run the node directly and use client without setting up the compi
 
 # Or Download & Build the source
 
-- Building the SCDO project requires both a Go (version 1.12.7 ONLY at this moment) compiler, Git, and a C compiler.
+- Building the SCDO project requires both a Go compiler, Git, and a C compiler. The current source tree is tested with Go 1.12.7 and GOPATH/vendor mode.
 
 - Clone the go-scdo repository to the GOPATH directory:
 
@@ -57,7 +57,7 @@ buildall.bat
 ```
 
 # Run SCDO
-A simple version SCDO mining tutorial: English-[SCDO MiningTutorial](https://scdo-project.gitbook.io/scdo-wiki/en/mining), 中文-[SCDO 挖矿教程中文简版](https://scdo-project.gitbook.io/scdo-wiki/zhong-wen/wa-kuang).
+A simple version SCDO mining tutorial: English-[SCDO MiningTutorial](https://scdo-project.gitbook.io/scdo-wiki/en/mining), Chinese-[SCDO Mining Tutorial](https://scdo-project.gitbook.io/scdo-wiki/zhong-wen/wa-kuang).
 
 For running a node, please refer to [Get Started](https://scdo-project.gitbook.io/scdo-wiki/developer/go-scdo/gettingstarted).
 For more usage details and deeper explanations, please consult the [SCDO Wiki](https://scdo-project.gitbook.io/scdo-wiki/).

--- a/buildall.bat
+++ b/buildall.bat
@@ -26,7 +26,7 @@ call :vm
 goto:eof
 
 :copylib
-for /f "delims=" %%i in ('go env GOPAH') do set gopath=%%i
+for /f "delims=" %%i in ('go env GOPATH') do set gopath=%%i
 for /f "delims=" %%i in ('go env GOOS') do set goos=%%i
 for /f "delims=" %%i in ('go env GOARCH') do set goarch=%%i
 md %gopath%\pkg\%goos%_%goarch%\github.com

--- a/cmd/node/cmd/start.go
+++ b/cmd/node/cmd/start.go
@@ -46,7 +46,9 @@ var (
 	// default is full node
 	lightNode bool
 
-	//pprofPort http server port
+	// pprofAddr is the host address for the pprof http server.
+	pprofAddr string
+	// pprofPort is the http server port for pprof.
 	pprofPort uint64
 
 	// profileSize is used to limit when need to collect profiles, set 6GB
@@ -105,7 +107,7 @@ var startCmd = &cobra.Command{
 		// start pprof http server
 		if pprofPort > 0 {
 			go func() {
-				if err := http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", pprofPort), nil); err != nil {
+				if err := http.ListenAndServe(fmt.Sprintf("%s:%d", pprofAddr, pprofPort), nil); err != nil {
 					fmt.Println("Failed to start pprof http server,", err)
 					return
 				}
@@ -230,7 +232,8 @@ func init() {
 	startCmd.Flags().StringVarP(&poolAccountsConfig, "poolaccounts", "", "", "init pool accounts")
 	startCmd.Flags().IntVarP(&threads, "threads", "", 1, "miner thread value")
 	startCmd.Flags().BoolVarP(&lightNode, "light", "l", false, "whether start with light mode")
-	startCmd.Flags().Uint64VarP(&pprofPort, "port", "", 0, "which port pprof http server listen to")
+	startCmd.Flags().StringVarP(&pprofAddr, "pprofaddr", "", "127.0.0.1", "which address pprof http server listens on")
+	startCmd.Flags().Uint64VarP(&pprofPort, "port", "", 0, "which port pprof http server listens on")
 	startCmd.Flags().IntVarP(&startHeight, "startheight", "", -1, "the block height to start from")
 	startCmd.Flags().IntVarP(&maxConns, "maxConns", "", 0, "node max connections")
 	startCmd.Flags().IntVarP(&maxActiveConns, "maxActiveConns", "", 0, "node max active connections")


### PR DESCRIPTION
## Summary
- fix the Windows build script so it reads GOPATH correctly
- make the pprof listen address configurable and default it to 127.0.0.1
- clarify the legacy Go/GOPATH build requirement and fix the mining tutorial link text

## Validation
- reviewed the GitHub compare diff: 3 files changed, 10 additions, 7 deletions
- not run locally because this environment does not have Go installed